### PR TITLE
Add RCON password input in settings and fix small error in eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,7 +55,8 @@
     "import/resolver": {
       "node": {},
       "typescript": {
-        "alwaysTryTypes": true // always try to resolve types under `<root>@types` directory even it doesn't contain any source code, like `@types/unist`
+        "alwaysTryTypes": true,
+        "project": "./tsconfig.json"
       }
     },
     "react": {

--- a/src/routes/settings/index.tsx
+++ b/src/routes/settings/index.tsx
@@ -5,13 +5,26 @@ import {
   ScrollArea,
   Stack,
   Text,
+  Group,
+  TextInput,
+  Button,
+  Tooltip,
 } from "@mantine/core";
+import { IconRefresh } from "@tabler/icons-react";
+import useStore from "@/hooks/useStore";
+import classes from "./settings.module.css";
 
 import BooleanSetting from "./BooleanSetting";
 import DemoDirsSetting from "./DemoDirsSetting";
 import { HeaderBar } from "@/AppShell";
 
 export default function SettingsView() {
+  const [rconPassword, setRconPassword] = useStore("rconPassword");
+
+  function generatePassword() {
+    setRconPassword(btoa(Math.random().toString()).substring(10, 20));
+  }
+
   return (
     <AppShell header={{ height: 50 }}>
       <AppShell.Header>
@@ -33,6 +46,26 @@ export default function SettingsView() {
         <ScrollArea h="100%">
           <Container size="xs" pt="md">
             <Stack>
+                <Group align="end" className={classes.rconPasswordRow}>
+                <TextInput
+                  label="RCON Password"
+                  description="Set or generate your own RCON password"
+                  placeholder="RCON Password"
+                  value={rconPassword !== null && rconPassword !== undefined ? rconPassword : ""}
+                  onChange={(e) => setRconPassword(e.currentTarget.value)}
+                  type="text"
+                  className={classes.rconPasswordInput}
+                />
+                <Tooltip label="Generate random password">
+                  <Button
+                  variant="default"
+                  onClick={generatePassword}
+                  leftSection={<IconRefresh size={16} />}
+                  >
+                  Generate
+                  </Button>
+                </Tooltip>
+                </Group>
               <BooleanSetting
                 name="Skip trash"
                 description="Delete demos permanently instead of moving them to trash"

--- a/src/routes/settings/settings.module.css
+++ b/src/routes/settings/settings.module.css
@@ -37,3 +37,14 @@
     }
   }
 }
+
+.rconPasswordRow {
+  width: 100%;
+  display: flex;
+  gap: var(--mantine-spacing-sm);
+}
+
+.rconPasswordInput {
+  flex-grow: 1;
+  align-items: center;
+}


### PR DESCRIPTION
## Pull Request: Add RCON Password Input with Generate Button in Settings

### Summary

This PR introduces a new RCON password input field with a "Generate" button in the settings page, and fixes a minor issue in the ESLint configuration.

### Changes

- Added an RCON password input and a generate button to the settings UI (`src/routes/settings/index.tsx`).
- Created/updated related CSS styles in `src/routes/settings/settings.module.css`.
- Fixed a small error in the ESLint settings (`.eslintrc.json`).

### Testing

- Verified that the RCON password input and generate button appear and function as expected in the settings page.
- Confirmed that ESLint runs without errors related to the configuration change.










