### PR TITLE
feat(settings): improve multi-directory demo support and on-the-fly f…

### DIFF
--- a/src/AppShell.module.css
+++ b/src/AppShell.module.css
@@ -1,3 +1,7 @@
+.auto-margin {
+  margin: auto;
+}
+
 .header-left,
 .header-center,
 .header-right {

--- a/src/routes/demos/demoDir/DemoList.tsx
+++ b/src/routes/demos/demoDir/DemoList.tsx
@@ -63,9 +63,10 @@ const createItemData = memoize(
 
 type DemoListProps = {
   demos: Demo[];
+  showDirectoryLabel?: boolean;
 };
 
-export default function DemoList({ demos }: DemoListProps) {
+export default function DemoList({ demos, showDirectoryLabel }: DemoListProps) {
   const listRef = useRef<FixedSizeList>(null);
 
   // TODO: update the page without reloading
@@ -190,7 +191,7 @@ export default function DemoList({ demos }: DemoListProps) {
                 style={{ overflow: "visible" }}
                 itemCount={demos.length}
                 itemSize={120 + PADDING_SIZE}
-                itemData={itemData}
+                itemData={{ ...itemData, showDirectoryLabel }}
                 innerElementType={innerElementType}
                 ref={listRef}
               >
@@ -215,10 +216,10 @@ export default function DemoList({ demos }: DemoListProps) {
 
 const Row = memo(
   ({
-    data: { demos, selectedRows, handleSelect },
+    data: { demos, selectedRows, handleSelect, showDirectoryLabel },
     index,
     style,
-  }: ListChildComponentProps<ItemDataType>) => (
+  }: ListChildComponentProps<ItemDataType & { showDirectoryLabel?: boolean }>) => (
     <div
       style={{
         ...style,
@@ -235,6 +236,7 @@ const Row = memo(
         onSelect={(event) => {
           handleSelect(event, index);
         }}
+        showDirectoryLabel={showDirectoryLabel}
       />
     </div>
   ),

--- a/src/routes/demos/demoDir/DemoListRow.module.css
+++ b/src/routes/demos/demoDir/DemoListRow.module.css
@@ -87,3 +87,12 @@
     background-color: var(--mantine-primary-color-filled);
   }
 }
+
+.dir-label-overlay {
+  position: absolute;
+  right: 12px;
+  bottom: 8px;
+  display: flex;
+  color: var(--mantine-color-white);
+  padding: 2px 8px;
+}

--- a/src/routes/demos/demoDir/DemoListRow.tsx
+++ b/src/routes/demos/demoDir/DemoListRow.tsx
@@ -45,7 +45,14 @@ type DemoListRowProps = {
   demo: Demo;
   selected: boolean;
   onSelect: React.MouseEventHandler;
+  showDirectoryLabel?: boolean;
 };
+
+// Extend Demo type for UI use to allow _demoDirLabel and _demoDirPath
+interface DemoWithDirLabel extends Demo {
+  _demoDirLabel?: string;
+  _demoDirPath?: string;
+}
 
 function HoverMenuItem({
   Icon,
@@ -76,6 +83,7 @@ export default function DemoListRow({
   demo,
   selected,
   onSelect,
+  showDirectoryLabel,
 }: DemoListRowProps) {
   const navigate = useNavigate();
 
@@ -85,6 +93,9 @@ export default function DemoListRow({
   const [rconPassword, _] = useStore("rconPassword");
 
   const birthtime = new Date(demo.birthtime * 1000);
+
+  // Use type assertion for extra fields
+  const demoWithDir = demo as DemoWithDirLabel;
 
   return (
     <Paper
@@ -119,6 +130,7 @@ export default function DemoListRow({
           )}
           <Badges items={demo.tags} max={3} />
         </Group>
+        {/* Directory label moved to bottom right overlay */}
         {!isStvDemo(demo) && (
           <Group gap={4}>
             <IconUser />
@@ -191,6 +203,13 @@ export default function DemoListRow({
           </HoverCard>
         )}
       </div>
+      {/* Directory label overlay at bottom right */}
+      {showDirectoryLabel === true && Boolean(demoWithDir._demoDirLabel) && (
+        <div className={classes.dirLabelOverlay}>
+          <IconFolder size={16} style={{ marginRight: 4 }} />
+          <Text c="dimmed" size="sm">{demoWithDir._demoDirLabel}</Text>
+        </div>
+      )}
       <Paper shadow="xl" withBorder className={classes.menu}>
         <HoverMenuItem
           Icon={IconTrash}

--- a/src/routes/settings/DemoDirsSetting.tsx
+++ b/src/routes/settings/DemoDirsSetting.tsx
@@ -12,17 +12,26 @@ import {
   TextInput,
   Tooltip,
 } from "@mantine/core";
-import { IconPlus, IconTrash } from "@tabler/icons-react";
+import { IconPlus, IconTrash, IconFolder, IconExternalLink } from "@tabler/icons-react";
+import { useNavigate } from "react-router";
+import { revealItemInDir } from "@tauri-apps/plugin-opener";
+import * as log from "@tauri-apps/plugin-log";
 
 import useStore from "@/hooks/useStore";
 import PathPicker from "./PathPicker";
+import BooleanSetting from "./BooleanSetting";
 
 import classes from "./settings.module.css";
 import { drop } from "@/util";
 
 export default function DemoDirsSetting() {
   const [demoDirs, setDemoDirs] = useStore("demoDirs");
+  // const [showMultipleDemoDirs, setShowMultipleDemoDirs] = useStore("showMultipleDemoDirs");
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [editPath, setEditPath] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState<string>("");
+  const [editingLabelPath, setEditingLabelPath] = useState<string | null>(null);
+  const [editingLabelValue, setEditingLabelValue] = useState<string>("");
   const form = useForm<{ label: string; path: string }>({
     initialValues: {
       label: "My Demos",
@@ -51,6 +60,8 @@ export default function DemoDirsSetting() {
     validateInputOnBlur: true,
   });
 
+  const navigate = useNavigate();
+
   return (
     <>
       <div className={classes.setting}>
@@ -72,13 +83,78 @@ export default function DemoDirsSetting() {
         <Text c="dimmed">
           These are the locations where DemoMan searches for demo files.
         </Text>
+        {/* Only show the toggle if there is more than one demo directory */}
+        {Object.keys(demoDirs).length > 1 && (
+          <div className={classes.showMultiDirToggle}>
+            <BooleanSetting
+              name="Show demos from all folders at once"
+              storeKey="showMultipleDemoDirs"
+            />
+          </div>
+        )}
         <Stack align="stretch" pt="md" gap="sm">
           {Object.entries(demoDirs).map(([path, label]) => (
             <div key={path} className={classes.demoDir}>
               <div className={classes.labelRow}>
-                <Text size="lg" fw={600} style={{ flex: 1 }}>
-                  {label}
-                </Text>
+                {editingLabelPath === path ? (
+                  <TextInput
+                    size="sm"
+                    value={editingLabelValue}
+                    autoFocus
+                    onChange={e => setEditingLabelValue(e.target.value)}
+                    onBlur={() => {
+                      if (editingLabelValue !== "" && editingLabelValue !== label) {
+                        setDemoDirs({ ...demoDirs, [path]: editingLabelValue });
+                      }
+                      setEditingLabelPath(null);
+                    }}
+                    onKeyDown={e => {
+                      if (e.key === "Enter") {
+                        if (editingLabelValue !== "" && editingLabelValue !== label) {
+                          setDemoDirs({ ...demoDirs, [path]: editingLabelValue });
+                        }
+                        setEditingLabelPath(null);
+                      } else if (e.key === "Escape") {
+                        setEditingLabelPath(null);
+                      }
+                    }}
+                    style={{ flex: 1, minWidth: 0 }}
+                  />
+                ) : (
+                  <Text
+                    size="lg"
+                    fw={600}
+                    className={classes.label}
+                    style={{ cursor: "pointer" }}
+                    title="Click to edit label"
+                    onClick={() => {
+                      setEditingLabelPath(path);
+                      setEditingLabelValue(label);
+                    }}
+                  >
+                    {label}
+                  </Text>
+                )}
+                <Group gap={4} className={classes["demoDirActions"]}>
+                  <Tooltip label="Open in DemoMan">
+                    <ActionIcon
+                      variant="subtle"
+                      color="blue"
+                      onClick={() => navigate(`/demos/dir/${btoa(path)}`)}
+                    >
+                      <IconFolder size={18} />
+                    </ActionIcon>
+                  </Tooltip>
+                  <Tooltip label="Open in File Explorer">
+                    <ActionIcon
+                      variant="subtle"
+                      color="gray"
+                      onClick={() => revealItemInDir(path).catch(log.error)}
+                    >
+                      <IconExternalLink size={18} />
+                    </ActionIcon>
+                  </Tooltip>
+                </Group>
                 <ActionIcon
                   variant="subtle"
                   color="red.9"
@@ -88,7 +164,15 @@ export default function DemoDirsSetting() {
                   <IconTrash />
                 </ActionIcon>
               </div>
-              <Text c="dimmed" style={{ wordBreak: "break-all" }}>
+              <Text
+                c="dimmed"
+                style={{ wordBreak: "break-all", cursor: "pointer" }}
+                onClick={() => {
+                  setEditPath(path);
+                  setEditValue(path);
+                }}
+                title="Click to change directory path"
+              >
                 {path}
               </Text>
             </div>
@@ -137,6 +221,61 @@ export default function DemoDirsSetting() {
             <Button type="submit">Submit</Button>
           </Group>
         </form>
+      </Modal>
+      <Modal
+        title="Edit demo directory path"
+        opened={editPath !== null}
+        centered
+        size="lg"
+        onClose={() => setEditPath(null)}
+      >
+        <Input.Wrapper label="Path" description="Select a new directory path">
+          <PathPicker
+            value={editValue}
+            setValue={setEditValue}
+          />
+        </Input.Wrapper>
+        <Group justify="flex-end" mt="md">
+          <Button
+            variant="default"
+            onClick={() => setEditPath(null)}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              if (
+                editPath === null ||
+                editPath === "" ||
+                editValue === null ||
+                editValue === "" ||
+                editValue === editPath
+              ) {
+                setEditPath(null);
+                return;
+              }
+              // Prevent duplicate paths
+              if (typeof editValue === "string" && editValue !== "" && demoDirs[editValue] !== undefined) {
+                // Optionally show error/notification here
+                setEditPath(null);
+                return;
+              }
+              const newDemoDirs = { ...demoDirs };
+              const label = newDemoDirs[editPath];
+              delete newDemoDirs[editPath];
+              newDemoDirs[editValue] = label;
+              setDemoDirs(newDemoDirs);
+              setEditPath(null);
+            }}
+            disabled={
+              editValue === "" ||
+              editValue === editPath ||
+              (editValue !== "" && demoDirs[editValue] !== undefined)
+            }
+          >
+            Save
+          </Button>
+        </Group>
       </Modal>
     </>
   );

--- a/src/routes/settings/settings.module.css
+++ b/src/routes/settings/settings.module.css
@@ -24,6 +24,7 @@
 .demo-dir {
   border-radius: var(--mantine-radius-md);
   padding: var(--mantine-spacing-xs);
+  position: relative;
 
   & .demo-dir-action {
     visibility: hidden;
@@ -38,6 +39,15 @@
   }
 }
 
+.demo-dir-actions {
+  visibility: hidden;
+  display: flex;
+}
+
+.demo-dir:hover .demo-dir-actions {
+  visibility: visible;
+}
+
 .rcon-password-row {
   width: 100%;
   display: flex;
@@ -46,4 +56,8 @@
 
 .rcon-password-input {
   flex-grow: 1;
+}
+
+.show-multi-dir-toggle {
+  margin-top: var(--mantine-spacing-md);
 }

--- a/src/store.ts
+++ b/src/store.ts
@@ -6,6 +6,7 @@ export type StoreSchema = {
   rconPassword: string;
   enableLocationOverlay: boolean;
   skipTrash: boolean;
+  showMultipleDemoDirs: boolean; // NEW: setting for showing multiple demo dirs
 };
 
 export function storeDefault<K extends keyof StoreSchema>(
@@ -18,6 +19,7 @@ export function storeDefault<K extends keyof StoreSchema>(
     rconPassword: () => btoa(Math.random().toString()).substring(10, 20),
     enableLocationOverlay: false,
     skipTrash: false,
+    showMultipleDemoDirs: false, // NEW: default to single folder mode
   };
 
   const defaultValue = storeDefaults[key];


### PR DESCRIPTION
## Add Multi-Directory Support and On-the-Fly Folder Changes

### Overview

This pull request introduces two major features:

- **Multi-Directory Support:**  
  Users can now add, manage, and interact with multiple demo directories within the application. This enables more flexible organization and access to demos stored in different locations. 

Button only shows if user has multiple folders added:
![image](https://github.com/user-attachments/assets/3b8a3c84-64fe-42e1-9b45-ff4af7e8fd3d)

Shows directory name on bottom right if multi-directory is enabled (removes if only single directory)
![image](https://github.com/user-attachments/assets/86a2319e-a592-4a73-986f-c9d18ba163e0)


- **On-the-Fly Folder Changes:**  
  The application now supports changing demo directories at runtime without requiring a restart. Users can switch, add, or remove directories seamlessly, and the UI will update to reflect the current state.

Users can now change on the fly folder locations, folder labels, button to open directly into that folder from settings, and button to open that folder in explorer.
![image](https://github.com/user-attachments/assets/48d61e46-a645-48d0-b167-165ba7fbea9d)

Supports copy paste text / browse file system:
![image](https://github.com/user-attachments/assets/329fe883-ada4-4ab9-b920-e10bc0f7e5c7)

### Key Changes

- Directory management logic to support multiple directories.
- Updated UI to allow users to add, remove, and switch between directories.
- Implemented state management for dynamic directory changes.
- Improved reloading to handle directory changes in real time.
- Added validation and error handling
- 
### Testing

- Verified adding, removing, and switching directories works as expected.
- Tested filters to ensure multi-directory support respected sort properties.
- Ensured UI updates correctly on directory changes.
- Tested with various directory structures and edge cases.