### PR TITLE
CI: Run on push to main

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,8 +1,12 @@
 name: Check PR
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    branches-ignore: ["v1"]
+    branches-ignore:
+      - v1
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This should keep the cargo cache warm and speed up other CI runs.
Only runs from `main` can create cache entries, but feature branches can use them.